### PR TITLE
Recognize Super and Hyper as bare modifier Qt keys

### DIFF
--- a/leo/plugins/qt_events.py
+++ b/leo/plugins/qt_events.py
@@ -271,6 +271,10 @@ class LeoQtEventFilter(QtCore.QObject):
             qt.Key_Shift: 'Key_Shift',
             qt.Key_NumLock: 'Num_Lock',
                 # 868.
+            qt.Key_Super_L: 'Key_Super_L',
+            qt.Key_Super_R: 'Key_Super_R',
+            qt.Key_Hyper_L: 'Key_Hyper_L',
+            qt.Key_Hyper_R: 'Key_Hyper_R',
         }
         if d.get(keynum):
             if 0: # Allow bare modifier key.


### PR DESCRIPTION
I'm using Leo editor on Linux. When I press just Windows key, following characters are added to text:

![Windows key produces text garbage on Linux](https://user-images.githubusercontent.com/509638/63901596-c1139500-c9f4-11e9-8c92-9291724d4196.png)

---

Due to being designed at the time of the space-cadet keyboard, X11 defined
the shift states "Meta", "Super", and "Hyper" (along with "Shift" and
"Control" and "Alt" which were commonly available on keyboards). Initially
on PC hardware it was just impossible to produce these shift states as there
was no key to push for them.

With the appearance of keyboards with the Windows key there was now a key
available on standard keyboards that could be used for one of these.
Initially, circa 1996, it was most common to make this key be the "Meta"
shift key. However, due to the high number of Emacs commands using "Meta",
there were already long-established replacements (the Alt key acted as Meta,
or typing Escape, X acted like Meta-X), so adding an actual Meta key did not
provide much added functionality. This made Super the first key of interest
in emulating, and therefore it became the standard assignment after a few
years.

Source: https://en.wikipedia.org/wiki/Super_key_(keyboard_button)